### PR TITLE
Removing android refrences from Package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "files": [
     "dist/",
     "ios/",
-    "android/",
     "CapacitorIosAppTracking.podspec"
   ],
   "keywords": [
@@ -36,9 +35,6 @@
     "ios": {
       "src": "ios"
     },
-    "android": {
-      "src": "android"
-    }
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
to prevent Build errors on Android

What went wrong:
Could not determine the dependencies of task ':app:compileReleaseJavaWithJavac'.
Could not resolve all task dependencies for configuration ':app:releaseCompileClasspath'.
Could not resolve project :capacitor-ios-app-tracking.
Required by:
project :app
Unable to find a matching configuration of project :capacitor-ios-app-tracking:
- None of the consumable configurations have attributes.