### PR TITLE
Fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "capacitor": {
     "ios": {
       "src": "ios"
-    },
+    }
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Plugin installation by `npm` was broken because the package.json wasn't a valid JSON. I fixed it and `npm install` is working now.