### PR TITLE
fix request permission response and handle ios versions below 14.0

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -9,26 +9,25 @@ import AdSupport
 @available(iOS 14, *)
 @objc(IOSAppTracking)
 public class IOSAppTracking: CAPPlugin {
-    
+
     @objc func getTrackingStatus(_ call: CAPPluginCall) {
         let advertising = ASIdentifierManager.init().advertisingIdentifier.uuidString
         let status : ATTrackingManager.AuthorizationStatus = ATTrackingManager.trackingAuthorizationStatus
         call.success([
             "value": advertising, "status": status.rawValue == 0 ? "unrequested" : status.rawValue == 1 ? "restricted" : status.rawValue == 2 ? "denied" : status.rawValue == 3 ? "authorized" : ""
         ])
-        
+
     }
 
     @objc func requestPermission(_ call: CAPPluginCall) {
-        let advertising = ASIdentifierManager.init().advertisingIdentifier.uuidString
-        var status: ATTrackingManager.AuthorizationStatus = ATTrackingManager.trackingAuthorizationStatus
         ATTrackingManager.requestTrackingAuthorization { (res) in
-            status = res
+            let advertising = ASIdentifierManager.init().advertisingIdentifier.uuidString
+            let status = res
+            call.success([
+                "value": advertising, "status": status.rawValue == 0 ? "unrequested" : status.rawValue == 1 ? "restricted" : status.rawValue == 2 ? "denied" : status.rawValue == 3 ? "authorized" : ""
+            ])
         }
-        call.success([
-            "value": advertising, "status": status.rawValue == 0 ? "unrequested" : status.rawValue == 1 ? "restricted" : status.rawValue == 2 ? "denied" : status.rawValue == 3 ? "authorized" : ""
-        ])
-        
+
      }
 
 }

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -6,28 +6,34 @@ import AdSupport
  * Please read the Capacitor iOS Plugin Development Guide
  * here: https://capacitor.ionicframework.com/docs/plugins/ios
  */
-@available(iOS 14, *)
 @objc(IOSAppTracking)
 public class IOSAppTracking: CAPPlugin {
 
     @objc func getTrackingStatus(_ call: CAPPluginCall) {
         let advertising = ASIdentifierManager.init().advertisingIdentifier.uuidString
-        let status : ATTrackingManager.AuthorizationStatus = ATTrackingManager.trackingAuthorizationStatus
-        call.success([
-            "value": advertising, "status": status.rawValue == 0 ? "unrequested" : status.rawValue == 1 ? "restricted" : status.rawValue == 2 ? "denied" : status.rawValue == 3 ? "authorized" : ""
-        ])
-
-    }
-
-    @objc func requestPermission(_ call: CAPPluginCall) {
-        ATTrackingManager.requestTrackingAuthorization { (res) in
-            let advertising = ASIdentifierManager.init().advertisingIdentifier.uuidString
-            let status = res
+        if #available(iOS 14.0, *) {
+            let status : ATTrackingManager.AuthorizationStatus = ATTrackingManager.trackingAuthorizationStatus
             call.success([
                 "value": advertising, "status": status.rawValue == 0 ? "unrequested" : status.rawValue == 1 ? "restricted" : status.rawValue == 2 ? "denied" : status.rawValue == 3 ? "authorized" : ""
             ])
+        } else {
+            call.success([ "value": advertising, "status": "authorized" ])
         }
+    }
 
+    @objc func requestPermission(_ call: CAPPluginCall) {
+        if #available(iOS 14.0, *) {
+            ATTrackingManager.requestTrackingAuthorization { (res) in
+                let advertising = ASIdentifierManager.init().advertisingIdentifier.uuidString
+                let status = res
+                call.success([
+                    "value": advertising, "status": status.rawValue == 0 ? "unrequested" : status.rawValue == 1 ? "restricted" : status.rawValue == 2 ? "denied" : status.rawValue == 3 ? "authorized" : ""
+                ])
+            }
+        } else {
+            let advertising = ASIdentifierManager.init().advertisingIdentifier.uuidString
+            call.success([ "value": advertising, "status": "authorized" ])
+        }
      }
 
 }


### PR DESCRIPTION
It fixes `requestPermission` method response because this was being returned before the `ATTrackingManager.requestTrackingAuthorization` finished. Like that, advertising ID and status were the previous ones before the permission request was completed.

Now, the return is only fired once the `ATTrackingManager.requestTrackingAuthorization` async method is completed and the returned value is always right according to the user permission request answer.

On the other hand, I added some logic to make the plugin work properly when the code is running on a device with iOS version lower than 14.0. The annotation `@available` in the class doesn't work good in a Capacitor plugin scenario because the compiler doesn't tell you anything and you can invoke the plugin method from the web side as if this annotation doesn't exist.  I know I should have done this change in another PR, sorry. If you think that it's important, I could do it.