### PR TITLE
fix: plugin invocation was broken after Capacitor 3 upgrade

### DIFF
--- a/ios/Plugin/IOSAppTrackingPluginPlugin.m
+++ b/ios/Plugin/IOSAppTrackingPluginPlugin.m
@@ -3,7 +3,7 @@
 
 // Define the plugin using the CAP_PLUGIN Macro, and
 // each method the plugin supports using the CAP_PLUGIN_METHOD macro.
-CAP_PLUGIN(IOSAppTracking, "IOSAppTracking",
+CAP_PLUGIN(IOSAppTracking, "AppTrackingTransparency",
            CAP_PLUGIN_METHOD(requestPermission, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(getTrackingStatus, CAPPluginReturnPromise);
 )


### PR DESCRIPTION
Hi,

the plugin invocation from web side is not working right now because the plugin is not properly configured on the iOS side. 

The name which is used to register the plugin from Javascript (https://github.com/migtam628/capacitor-ios-app-tracking/blob/master/src/index.ts#L6) doesn't match with the one used on the iOS CAP_PLUGIN Macro (https://github.com/migtam628/capacitor-ios-app-tracking/blob/master/ios/Plugin/IOSAppTrackingPluginPlugin.m#L6).

Please, I would be glad this PR would be accepted as soon as possible because the plugin is completely broken.

Thanks in advance,